### PR TITLE
Update worker.js - fix TTS example

### DIFF
--- a/examples/text-to-speech-client/src/worker.js
+++ b/examples/text-to-speech-client/src/worker.js
@@ -25,14 +25,14 @@ class MyTextToSpeechPipeline {
 
         if (this.model_instance === null) {
             this.model_instance = SpeechT5ForTextToSpeech.from_pretrained(this.model_id, {
-                quantized: false,
+                dtype: 'fp32',
                 progress_callback,
             });
         }
 
         if (this.vocoder_instance === null) {
             this.vocoder_instance = SpeechT5HifiGan.from_pretrained(this.vocoder_id, {
-                quantized: false,
+                dtype: 'fp32',
                 progress_callback,
             });
         }


### PR DESCRIPTION
I added the `dtype: 'fp32',` tip you gave me earlier, so the example should then work again.